### PR TITLE
Add --stop flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Command used in this demo: `giph -s -l -c 0.3,0,0.6,0.3 ~/Videos/$(date +%s).gif
 ```bash
 $ giph -s -l -c 1,1,1,0.3 -b 5 -p -5 out.gif 
 ```
-Select a window or area with slop. The selection rectangle is highlighted in a transparent blue color abd has a 5px border on the inside. After stopping the recording with either `ctrl+c` or by sending a `SIGINT` to the processgroup, the resulting gif is written to `out.gif`.
+Select a window or area with slop. The selection rectangle is highlighted in a transparent blue color abd has a 5px border on the inside. 
+After stopping the recording with either `ctrl+c`, by running `giph --stop` or by sending a `SIGINT` to the processgroup, the resulting gif is written to `out.gif`.
 
 
 ```bash
@@ -39,6 +40,7 @@ Optionally, install the following dependencies:
 
  - slop (`--select`)
  - libnotify (`--notify`)
+ - pgrep (`--stop`)
 
 Clone the giph repository:
 

--- a/man/giph.1
+++ b/man/giph.1
@@ -21,19 +21,17 @@ is a screen recorder that records the desktop, a window or selection and encodes
 .BI "giph -g " "300x200+600+200 ~/Videos/$(date +%s).png"
 Records a 300x200 pixel (width x height) rectangle, that is shifted 600 pixel to the right and 200 pixel down from the top-left corner. The recording stops when either 
 .B ctrl+c
-is pressed, or the 
-.BR "process group is interrupted" .
-The encoded gif will be saved in your users Videos directory and has the current timestamp as a name. To send an interrupt signal to the process group, you can use:
-.in +2
-\(bu
-.BI "kill -INT -" PID
+is pressed, or after calling
+.B giph --stop.
 .br
-\(bu
-.BI "killall -INT -g " giph
+The encoded gif will be saved in your users videos directory and has the current timestamp as a name.
 .SH OPTIONS
 .TP
 .BR \-h ", " \-\-help
 Print help and exit.
+.TP
+.BR \-\-stop
+Finish any running giph recordings
 .TP
 .BR \-\-version
 Print version and exit.

--- a/src/giph
+++ b/src/giph
@@ -37,6 +37,7 @@ OPTIONS
   -t,  --timer=TIMEDURATION   Time of the recording. (e.g. 10 for 10 seconds or 1:30 for 1 minute 30 seconds)
   -f,  --framerate=INT        Set the framerate.
   -y,  --notify               Send notification on error or success.
+       --stop                 Finish any running giph recordings.
 
 SLOP OPTIONS
   -b, --bordersize=FLOAT                Set the selection border thickness.
@@ -114,6 +115,9 @@ while [[ "$1" == -* ]]; do
     ;;
   --quiet)
     VERBOSITY=-1
+    ;;
+  --stop)
+    SHOULD_STOP=true
     ;;
   -s|--select)
     SLOP=1
@@ -341,10 +345,12 @@ function countdown_cli() {
   done
 }
 
+
 function stop_recording_handler_cli() {
-  log_info "stop recording with \033[1;36mctrl+c\033[0m or send INT SIGNAL to this process \033[1;36mkillall -int -g giph\033[0m" 
+  log_info "stop recording with \033[1;36mctrl+c\033[0m or call \033[1;36mgiph --stop\033[0m"
   trap '' INT
 }
+
 
 function encode_gif_ffmpeg() {
   log "encoding gif using ffmpeg encoder" 1 true
@@ -389,5 +395,15 @@ function giph() {
   exit 0
 }
 
-giph
+function stop_all_recordings() {
+  for pid in $(pgrep giph); do
+    kill -INT -"$pid"
+  done
+}
+
+if [ -n "$SHOULD_STOP" ]; then
+  stop_all_recordings
+else
+  giph
+fi
 wait


### PR DESCRIPTION
This PR adds the `--stop` flag. This flag sends the SIGINT-signal to all all  `giph` processes, stopping the recording.
To implement this, there is a new optional dependency on `pgrep`.