### PR TITLE
Support countdown via notification

### DIFF
--- a/src/giph
+++ b/src/giph
@@ -17,6 +17,9 @@ MICROPHONE=0
 MICROPHONE_SOURCE=default
 FORMAT_OVERWRITE=""
 
+# last notification id
+LAST_NOTIFICATION_ID=0
+
 function print_version() {
   echo "$VERSION"
   exit 0
@@ -96,12 +99,33 @@ function log_info() {
   log "\033[0;36mINFO:\033[0m $1" 0 "${2:-true}"
 }
 
+# send a notification - (message:string, urgency:string, durationms:int)
 function notify() {
   [ "$NOTIFY" = 1 ] && {
-    notify=(notify-send -t 3000)
-    notify+=(-u "$2")
-    notify+=("giph" "$1")
-    "${notify[@]}"
+    case "$2" in
+        low) URGENCY=0 ;;
+        normal) URGENCY=1 ;;
+        critical) URGENCY=2 ;;
+    esac
+    LAST_NOTIFICATION_ID=$(gdbus call \
+      --session \
+      --dest=org.freedesktop.Notifications \
+      --object-path=/org/freedesktop/Notifications \
+      --method=org.freedesktop.Notifications.Notify \
+      "giph" "$LAST_NOTIFICATION_ID" "" "giph" "$1" \
+      '[]' '{"urgency": <'$URGENCY'>}' "${3:-5000}" | sed -E 's/^.* ([0-9]+).*$/\1/')
+  }
+}
+
+# closes the last notification
+function close_notification() {
+  [ "$NOTIFY" = 1 ] && {
+    gdbus call \
+      --session \
+      --dest org.freedesktop.Notifications \
+      --object-path /org/freedesktop/Notifications \
+      --method org.freedesktop.Notifications.CloseNotification "$LAST_NOTIFICATION_ID"
+    LAST_NOTIFICATION_ID=0
   }
 }
 
@@ -399,10 +423,12 @@ function countdown_cli() {
   seconds="$1"
   while [ "$seconds" -ge 0 ]; do
     log "\r\033[K\033[0;36m$2:\033[0m $seconds" 0 false false true
+    notify "$2 $seconds" "normal" 2000
     if [ "$seconds" -gt 0 ]; then
       sleep 1
     else
       log "\r\033[K" 0 false false true
+      close_notification
     fi
     : "$((seconds--))"
   done

--- a/src/giph
+++ b/src/giph
@@ -17,7 +17,6 @@ MICROPHONE=0
 MICROPHONE_SOURCE=default
 FORMAT_OVERWRITE=""
 
-# last notification id
 LAST_NOTIFICATION_ID=0
 
 function print_version() {
@@ -82,7 +81,7 @@ function log() {
 }
 
 function log_error() {
-  notify "$1" "critical"
+  notify "$1"
   log "\033[0;31mERROR:\033[0m $1" -1 "${2:-true}" true
 }
 
@@ -91,7 +90,7 @@ function log_warning() {
 }
 
 function log_success() {
-  notify "$1" "normal"
+  notify "$1"
   log "\033[0;32mSUCCESS:\033[0m $1" 0 "${2:-true}"
 }
 
@@ -99,26 +98,20 @@ function log_info() {
   log "\033[0;36mINFO:\033[0m $1" 0 "${2:-true}"
 }
 
-# send a notification - (message:string, urgency:string, durationms:int)
+# send a notification - (message:string, durationms:int)
 function notify() {
   [ "$NOTIFY" = 1 ] && {
-    case "$2" in
-        low) URGENCY=0 ;;
-        normal) URGENCY=1 ;;
-        critical) URGENCY=2 ;;
-    esac
     LAST_NOTIFICATION_ID=$(gdbus call \
       --session \
       --dest=org.freedesktop.Notifications \
       --object-path=/org/freedesktop/Notifications \
       --method=org.freedesktop.Notifications.Notify \
       "giph" "$LAST_NOTIFICATION_ID" "" "giph" "$1" \
-      '[]' '{"urgency": <'$URGENCY'>}' "${3:-5000}" | sed -E 's/^.* ([0-9]+).*$/\1/')
+      '[]' '{"urgency": <1>}' "${3:-5000}" | sed -E 's/^.* ([0-9]+).*$/\1/')
   }
 }
 
-# closes the last notification
-function close_notification() {
+function close_last_notification() {
   [ "$NOTIFY" = 1 ] && {
     gdbus call \
       --session \
@@ -397,7 +390,7 @@ function record() {
       ;;
   esac
 
-  [ -n "$DELAY" ] && [ "$DELAY" -gt 0 ] && countdown_cli "$DELAY" "recording starts in"
+  [ -n "$DELAY" ] && [ "$DELAY" -gt 0 ] && countdown "$DELAY" "recording starts in"
 
   ffmpeg_command="${ffmpeg[*]}"
   log "ffmpeg command: '$ffmpeg_command'" 2 true
@@ -408,7 +401,7 @@ function record() {
   log "started recording video with ffmpeg" 1 true
 
   if [ -n "$TIMER" ] && [ "$TIMER" -gt 0 ]; then
-    countdown_cli "$TIMER" "recording stops in"
+    countdown "$TIMER" "recording stops in"
   else
     stop_recording_handler_cli
   fi
@@ -419,16 +412,16 @@ function record() {
   log "completed ffmpeg video recording" 1 true
 }
 
-function countdown_cli() {
+function countdown() {
   seconds="$1"
   while [ "$seconds" -ge 0 ]; do
     log "\r\033[K\033[0;36m$2:\033[0m $seconds" 0 false false true
-    notify "$2 $seconds" "normal" 2000
+    notify "$2 $seconds" 2000
     if [ "$seconds" -gt 0 ]; then
       sleep 1
     else
       log "\r\033[K" 0 false false true
-      close_notification
+      close_last_notification
     fi
     : "$((seconds--))"
   done


### PR DESCRIPTION
Fixes #14. I've switched the `notify` function to use `gdbus` instead of `notify-send` since the latter doesn't seem to support replacing/closing existing notifications.

![demo](https://user-images.githubusercontent.com/44368997/119230438-cbb37d80-bb39-11eb-926d-b7bc0beee00e.gif)