### PR TITLE
Make giph stop all previous recordings properly

### DIFF
--- a/src/giph
+++ b/src/giph
@@ -471,7 +471,7 @@ function giph() {
 
 function stop_all_recordings() {
   for pid in $(pgrep -f "bash.+giph"); do
-    if [ "$pid" -eq $$ ]; then
+    if [ $pid -eq $$ ]; then
       continue
     fi
     record_pid=$(pgrep -P $pid -f "ffmpeg -f x11grab")

--- a/src/giph
+++ b/src/giph
@@ -2,20 +2,13 @@
 
 stty -echoctl # don't print ^C when pressing ctrl+c
 
+signal_usr1_handled=false
 function handle_usr1(){
-  if [[ $FFMPEG_PID ]]; then
-    kill -int "$FFMPEG_PID"
-    FFMPEG_PID=""
-
-    wait
-
-    [ "$?" = 1 ] && log_error "recording video with ffmpeg failed"
-    log "completed ffmpeg video recording" 1 true
-
-    convert
-    wait
-
-    exit
+  # Ensure giph only receives SIGUSR1 ONCE
+  if [[ -n $FFMPEG_PID && "$signal_usr1_handled" == false ]]; then
+    signal_usr1_handled=true
+    kill $FFMPEG_PID 
+    wait $FFMPEG_PID
   fi
 }
 
@@ -68,7 +61,7 @@ OPTIONS
   -ms, --microphone-source=STRING   Overwrite the default microphone source.
   -y,  --notify                     Send notification on error or success.
        --stop                       Finish any running giph recordings.
-       --finish                     Finish any screen recordings only.
+       --kill                       Abort all giph recordings.
 
 SLOP OPTIONS
   -b, --bordersize=FLOAT                Set the selection border thickness.
@@ -150,8 +143,8 @@ while [[ "$1" == -* ]]; do
   --stop)
     SHOULD_STOP=true
     ;;
-  --finish)
-    SHOULD_FINISH=true
+  --kill)
+    SHOULD_KILL=true
     ;;
   -s|--select)
     SLOP=1
@@ -477,13 +470,11 @@ function delete_temporary_directory() {
   log "deleted temporary directory $TEMP_DIRECTORY" 2 true
 }
 
-function prepare() {
+function giph() {
   get_geometry
   create_temporary_directory
   record
-}
 
-function convert() {
   if [[ "$FORMAT" == "gif" || "$FORMAT" == "webm" ]]; then
     encode
   fi
@@ -492,37 +483,25 @@ function convert() {
 
   delete_temporary_directory
   exit 0
-
-}
-function giph() {
-  prepare
-  convert
 }
 
 
 function stop_all_recordings() {
   for pid in $(pgrep -f "bash.+giph"); do
-    if [ $pid -eq $$ ]; then
-      continue
-    fi
-    kill -INT -$pid
-  done
-}
-
-
-function stop_recording_only() {
-  for pid in $(pgrep -f "bash.+giph"); do
-    if [ "$pid" -eq $$ ]; then
-      continue
-    fi
     kill -USR1 $pid
   done
 }
 
+
+# Todo
+function abort_all_recordings() {
+  :
+}
+
 if [ -n "$SHOULD_STOP" ]; then
   stop_all_recordings
-elif [ -n "$SHOULD_FINISH" ]; then
-  stop_recording_only
+elif [ -n "$SHOULD_KILL" ]; then
+  abort_all_recordings
 else
   giph
 fi

--- a/src/giph
+++ b/src/giph
@@ -470,8 +470,14 @@ function giph() {
 }
 
 function stop_all_recordings() {
-  for pid in "$(pgrep -f "bash.+giph")"; do
-    kill -INT -$pid
+  for pid in $(pgrep -f "bash.+giph"); do
+    if [ "$pid" -eq $$ ]; then
+      continue
+    fi
+    record_pid=$(pgrep -P $pid -f "ffmpeg -f x11grab")
+    if [ -n "$record_pid" ]; then
+      kill -INT $record_pid
+    fi
   done
 }
 

--- a/src/giph
+++ b/src/giph
@@ -2,6 +2,25 @@
 
 stty -echoctl # don't print ^C when pressing ctrl+c
 
+function handle_usr1(){
+  if [[ $FFMPEG_PID ]]; then
+    kill -int "$FFMPEG_PID"
+    FFMPEG_PID=""
+
+    wait
+
+    [ "$?" = 1 ] && log_error "recording video with ffmpeg failed"
+    log "completed ffmpeg video recording" 1 true
+
+    convert
+    wait
+
+    exit
+  fi
+}
+
+trap handle_usr1 SIGUSR1
+
 readonly VERSION=1.1.1
 
 # verbosity
@@ -49,6 +68,7 @@ OPTIONS
   -ms, --microphone-source=STRING   Overwrite the default microphone source.
   -y,  --notify                     Send notification on error or success.
        --stop                       Finish any running giph recordings.
+       --finish                     Finish any screen recordings only.
 
 SLOP OPTIONS
   -b, --bordersize=FLOAT                Set the selection border thickness.
@@ -129,6 +149,9 @@ while [[ "$1" == -* ]]; do
     ;;
   --stop)
     SHOULD_STOP=true
+    ;;
+  --finish)
+    SHOULD_FINISH=true
     ;;
   -s|--select)
     SLOP=1
@@ -454,11 +477,13 @@ function delete_temporary_directory() {
   log "deleted temporary directory $TEMP_DIRECTORY" 2 true
 }
 
-function giph() {
+function prepare() {
   get_geometry
   create_temporary_directory
   record
+}
 
+function convert() {
   if [[ "$FORMAT" == "gif" || "$FORMAT" == "webm" ]]; then
     encode
   fi
@@ -467,22 +492,37 @@ function giph() {
 
   delete_temporary_directory
   exit 0
+
 }
+function giph() {
+  prepare
+  convert
+}
+
 
 function stop_all_recordings() {
   for pid in $(pgrep -f "bash.+giph"); do
     if [ $pid -eq $$ ]; then
       continue
     fi
-    record_pid=$(pgrep -P $pid -f "ffmpeg -f x11grab")
-    if [ -n "$record_pid" ]; then
-      kill -INT $record_pid
+    kill -INT -$pid
+  done
+}
+
+
+function stop_recording_only() {
+  for pid in $(pgrep -f "bash.+giph"); do
+    if [ "$pid" -eq $$ ]; then
+      continue
     fi
+    kill -USR1 $pid
   done
 }
 
 if [ -n "$SHOULD_STOP" ]; then
   stop_all_recordings
+elif [ -n "$SHOULD_FINISH" ]; then
+  stop_recording_only
 else
   giph
 fi

--- a/src/giph
+++ b/src/giph
@@ -7,12 +7,21 @@ function handle_usr1(){
   # Ensure giph only receives SIGUSR1 ONCE
   if [[ -n $FFMPEG_PID && "$signal_usr1_handled" == false ]]; then
     signal_usr1_handled=true
-    kill $FFMPEG_PID 
+    kill $FFMPEG_PID
     wait $FFMPEG_PID
   fi
 }
 
+function handle_usr2(){
+  if [[ -n $FFMPEG_PID ]]; then
+    kill -KILL $FFMPEG_PID
+  fi
+  delete_temporary_directory
+  exit 1
+}
+
 trap handle_usr1 SIGUSR1
+trap handle_usr2 SIGUSR2
 
 readonly VERSION=1.1.1
 
@@ -493,9 +502,10 @@ function stop_all_recordings() {
 }
 
 
-# Todo
 function abort_all_recordings() {
-  :
+  for pid in $(pgrep -f "bash.+giph"); do
+    kill -USR2 $pid
+  done
 }
 
 if [ -n "$SHOULD_STOP" ]; then


### PR DESCRIPTION
I'm new to giph and I love the tiny and elegant program very much! But sometimes I find `giph --stop` not working properly. After investigating, I find two main problems:

1. `"$(pgrep -f "bash.+giph")"` will return all pids as a single **string**. So after starting multiple giph records,  `giph --stop` can only stop at most one previous record. 
2. Currently when executing `giph --stop`, It will send SIGINT to all running giph processes as well as their child processes. This has caused me some trouble because I'm using keyboard shortcut and when I accidently executed this command twice, the `encode()` bash function will be interrupted. So I will lose all the screen records and only get an empty gif file. I modified `stop_all_recordings` in order to kill giph's record child process accurately.

